### PR TITLE
Add inputs.args parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: "Install directory"
     default: ''
     required: false
+  args:
+    description: Octocov command line arguments
+    default: ''
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -52,7 +56,7 @@ runs:
           const path = require('path');
           const inputs = ${{ toJSON(inputs) }};
           const toolpath = inputs['install-dir'] != '' ? path.join(inputs['install-dir'], 'octocov') : await io.which('octocov', true)
-          const opt = `--config=${inputs.config}`
+          const opt = `--config=${inputs.config} ${inputs.args}`
           const options = {};
           if (inputs.workdir != '') {
             core.warning('Using workdir: to set working directory is deprecated. Use work-dir: instead.')


### PR DESCRIPTION
I added `inputs.args` parameter to pass arbitrary options for octocov.

https://github.com/k1LoW/octocov/issues/406

There are other ways, for example adding `inputs.report-path` option, however *octocov* has many options and subcommands so `inputs.args` is useful I think.