### PR TITLE
fix: pin dependencies

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./
         with:
           config: testdata/path/to/.octocov.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./
         with:
           work-dir: testdata/path/to
@@ -34,7 +34,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./
         with:
           config: testdata/path/to/.octocov.yml

--- a/.github/workflows/tag-v0.yml
+++ b/.github/workflows/tag-v0.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     -
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: docker-action
     -
-      uses: haya14busa/action-update-semver@v1
+      uses: haya14busa/action-update-semver@fb48464b2438ae82cc78237be61afb4f461265a1 # v1.2.1
       with:
         major_version_tag_only: true

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,13 +13,13 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - id: run-tagpr
         name: Run tagpr
-        uses: Songmu/tagpr@v1
+        uses: Songmu/tagpr@e89d37247ca73d3e5620bf074a53fbd5b39e66b0 # v1.5.1
 
-      - uses: haya14busa/action-update-semver@v1
+      - uses: haya14busa/action-update-semver@fb48464b2438ae82cc78237be61afb4f461265a1 # v1.2.1
         if: "steps.run-tagpr.outputs.tag != ''"
         with:
           major_version_tag_only: true

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+files:
+  - pattern: "^\\.github/workflows/.*\\.ya?ml$"
+  - pattern: "^(.*/)?action\\.ya?ml$"
+
+ignore_actions:
+# - name: actions/checkout
+# - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Version of octocov
     default: latest
     required: false
+  checksum:
+    description: Checksum of octocov
+    default: ''
+    required: false
   check-existence:
     description: Check for the existence of an existing octocov
     default: 'false'
@@ -39,18 +43,19 @@ runs:
   using: 'composite'
   steps:
     -
-      uses: k1LoW/gh-setup@v1
+      uses: k1LoW/gh-setup@e2f12d046abe942ed4e6976980e53e2388238273 # v1.10.0
       with:
         repo: github.com/k1LoW/octocov
         github-token: ${{ inputs.github-token }}
         version: ${{ inputs.version }}
         bin-dir: ${{ inputs.install-dir }}
         bin-match: octocov
+        checksum: ${{ inputs.checksum }}
         strict: true
         force: ${{ inputs.check-existence != 'true' }}
     -
       name: Run octocov
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
           const path = require('path');


### PR DESCRIPTION
This pull request includes updates to various GitHub Actions workflows and configuration files to use specific versions of actions and add new inputs. The most important changes include specifying exact commit hashes for action versions, adding a new input to the `action.yml` file, and updating the `.pinact.yaml` configuration.

### Updates to GitHub Actions workflows:

* [`.github/workflows/integration.yml`](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL13-R13): Updated `actions/checkout` to use commit `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) in multiple steps. [[1]](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL13-R13) [[2]](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL25-R25) [[3]](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL37-R37)
* [`.github/workflows/tag-v0.yml`](diffhunk://#diff-402115fdf3583529b8815f5290d043fed0671ae6553d802630b1893005ef00f3L12-R16): Updated `actions/checkout` to use commit `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) and `haya14busa/action-update-semver` to use commit `fb48464b2438ae82cc78237be61afb4f461265a1` (v1.2.1).
* [`.github/workflows/tagpr.yml`](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eL16-R22): Updated `actions/checkout` to use commit `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2), `Songmu/tagpr` to use commit `e89d37247ca73d3e5620bf074a53fbd5b39e66b0` (v1.5.1), and `haya14busa/action-update-semver` to use commit `fb48464b2438ae82cc78237be61afb4f461265a1` (v1.2.1).

### Configuration updates:

* [`.pinact.yaml`](diffhunk://#diff-1b47a32c39c399a254e38249e6181f10bd94bcadd6f796b16fb82480e90740d5R1-R9): Added a new configuration file with patterns to match workflow files and ignore specific actions.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R15-R18): Added a new `checksum` input and updated the `k1LoW/gh-setup` action to use commit `e2f12d046abe942ed4e6976980e53e2388238273` (v1.10.0) and `actions/github-script` to use commit `60a0d83039c74a4aee543508d2ffcb1c3799cdea` (v7.0.1). [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R15-R18) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L42-R58)