### PR TITLE
chore(deps): bump k1LoW/gh-setup from 1.11.8 to 1.11.9

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
   using: 'composite'
   steps:
     -
-      uses: k1LoW/gh-setup@5134fd4fc448da9cca216b2298af4bee28a4eed2 # v1.11.8
+      uses: k1LoW/gh-setup@5fb38d34ea857e5a942b6fe10f1723e55055f6c0 # v1.11.9
       with:
         repo: github.com/k1LoW/octocov
         github-token: ${{ inputs.github-token }}


### PR DESCRIPTION
Bump `k1LoW/gh-setup` in `action.yml` from v1.11.8 to v1.11.9.

Pinned to the commit SHA of the v1.11.9 tag (`5fb38d3`) to keep `.pinact.yaml` conventions.

https://github.com/k1LoW/gh-setup/releases/tag/v1.11.9